### PR TITLE
Allow #change work without active support core-ext

### DIFF
--- a/examples/009_change_spec.rb
+++ b/examples/009_change_spec.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+require 'preamble'
+
+describe 'change' do
+  it 'tracks a single change' do
+    a = 1
+    lambda do
+      a += 1
+    end.should.change('a', +1)
+  end
+
+  it 'tracks multiple changes' do
+    a = 1
+    b = 4
+    lambda do
+      a += 1
+      b -= 1
+    end.should.change('a', +1, 'b', -1)
+  end
+end
+
+# We need to specs to run now, not at exit because we want to inspect
+# the outcomes.
+
+Peck.run
+
+require 'assert'
+
+assert(Peck.counter.ran == 2,
+  "Expected five specification to have been run")
+
+assert(Peck.counter.passed == 2,
+  "Expected five specification to have passed")
+

--- a/lib/peck/expectations.rb
+++ b/lib/peck/expectations.rb
@@ -69,13 +69,13 @@ class Peck
     def change(*expected)
       block_binding = @this.send(:binding)
 
-      before = expected.in_groups_of(2).map do |expression, _|
+      before = expected.each_slice(2).map do |expression, _|
         eval(expression, block_binding)
       end
 
       block_result = @this.call
 
-      expected.in_groups_of(2).each_with_index do |(expression, change), index|
+      expected.each_slice(2).with_index do |(expression, change), index|
         after = eval(expression, block_binding)
         actual = after - before[index]
 


### PR DESCRIPTION
Before this change, the `.change` expectation did not work without `activesupport/lib/active_support/core_ext/array/grouping.rb` overloading `Array` to add `in_groups_of`. 

`.each_slice` is defined in ruby on `Enumerable` and makes it work without active support core extensions.

I've added a new example to show it's working, you can try it on your master-branch to see it fail. Let me know if the pull-request needs work.

Fijne avond! <3