### PR TITLE
Add an #eq matcher that works like ==

### DIFF
--- a/lib/peck/expectations.rb
+++ b/lib/peck/expectations.rb
@@ -132,6 +132,20 @@ class Peck
       end
     end
 
+    # Matches if the object equals another object using == internally. We use
+    # this method so you can write specs without triggering Ruby syntax
+    # warnings, but still test == equality.
+    def eq(other)
+      if @negated
+        description = "expected `#{self}' to not == `#{other}'"
+      else
+        description = "expected `#{self}' to == `#{other}'"
+      end
+      satisfy(description) do
+        @this == other
+      end
+    end
+
     PREDICATE_METHOD_RE = /\w[^?]\z/
     def method_missing(name, *args, &block)
       name = "#{name}?" if name.to_s =~ PREDICATE_METHOD_RE

--- a/lib/peck/expectations.rb
+++ b/lib/peck/expectations.rb
@@ -137,9 +137,9 @@ class Peck
     # warnings, but still test == equality.
     def eq(other)
       if @negated
-        description = "expected `#{self}' to not == `#{other}'"
+        description = "expected `#{@this}' to not == `#{other}'"
       else
-        description = "expected `#{self}' to == `#{other}'"
+        description = "expected `#{@this}' to == `#{other}'"
       end
       satisfy(description) do
         @this == other

--- a/spec/expectations_spec.rb
+++ b/spec/expectations_spec.rb
@@ -65,4 +65,16 @@ describe "A common", Peck::Should do
     @should.not.object_id.should.eql(@should.object_id)
     @should.instance_variable_get('@negated').should.eql(true)
   end
+
+  it "equality is successful when objects are equal" do
+    lambda do
+      @should.eq(@subject)
+    end.should.not.raise
+  end
+
+  it "equality fails when objects are not equal" do
+    lambda do
+      @should.eq(12)
+    end.should.raise(Peck::Error)
+  end
 end


### PR DESCRIPTION
We can use it to write specs which don't trigger warnings.
